### PR TITLE
It turns out that this is the real HOT one

### DIFF
--- a/src/Nullkooland.Client/Services/Theme/LocalThemeService.cs
+++ b/src/Nullkooland.Client/Services/Theme/LocalThemeService.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -16,7 +16,7 @@ namespace Nullkooland.Client.Services.Theme
         private readonly HttpClient _client;
         private readonly IJSRuntime _jsRuntime;
 
-        private ImmutableDictionary<OolandThemeType, OolandTheme> _themes;
+        private Dictionary<OolandThemeType, OolandTheme> _themes;
 
         public LocalThemeService(HttpClient client, IJSRuntime jsRuntime)
         {
@@ -36,7 +36,7 @@ namespace Nullkooland.Client.Services.Theme
                 }
             };
 
-            var themes = await _client.GetFromJsonAsync<ImmutableDictionary<OolandThemeType, OolandTheme>>("themes.json", jsonOptions);
+            var themes = await _client.GetFromJsonAsync<Dictionary<OolandThemeType, OolandTheme>>("themes.json", jsonOptions);
             _themes = themes!;
 
             bool isDarkMode = await _jsRuntime.InvokeAsync<bool>("darkModeHelper.isDarkMode");


### PR DESCRIPTION
Seems to be related to dotnet/aspnetcore#35598
If I deserialize the `themes.json` as an `ImmutableDictionary<OolandThemeType, OolandTheme>`, it will fail in the published version due to trimming.