### PR TITLE
思源宋体替霞鹜，平平淡淡才是真

### DIFF
--- a/src/Nullkooland.Client/Services/Markdown/MarkdownRenderService.cs
+++ b/src/Nullkooland.Client/Services/Markdown/MarkdownRenderService.cs
@@ -36,10 +36,12 @@ namespace Nullkooland.Client.Services.Markdown
             var paragraphRenderer = _renderer.ObjectRenderers.FindExact<ParagraphRenderer>();
             var autolinkRenderer = _renderer.ObjectRenderers.FindExact<AutolinkInlineRenderer>();
             var linkRenderer = _renderer.ObjectRenderers.FindExact<LinkInlineRenderer>();
+            var headingsRenderer = _renderer.ObjectRenderers.FindExact<HeadingsRenderer>();
 
             paragraphRenderer!.FontFamily = fontFamily;
             autolinkRenderer!.FontFamily = fontFamily;
             linkRenderer!.FontFamily = fontFamily;
+            headingsRenderer!.FontFamily = fontFamily;
 
             linkRenderer!.BaseUrl = baseUrl;
 

--- a/src/Nullkooland.Client/Services/Markdown/Renderers/HeadingRenderer.cs
+++ b/src/Nullkooland.Client/Services/Markdown/Renderers/HeadingRenderer.cs
@@ -7,6 +7,8 @@ namespace Nullkooland.Client.Services.Markdown.Renderers
 {
     public class HeadingsRenderer : RazorComponentObjectRenderer<HeadingBlock>
     {
+        public string FontFamily { get; set; } = "sans-serif";
+
         private static readonly Typo[] _headingTypos =
         {
             Typo.h4, // Level 2
@@ -40,6 +42,7 @@ namespace Nullkooland.Client.Services.Markdown.Renderers
             builder.AddAttribute(renderer.Sequence++, "id", id);
             builder.AddAttribute(renderer.Sequence++, "Class", $"my-{6 - level}");
             builder.AddAttribute(renderer.Sequence++, "Typo", _headingTypos[level - 2]);
+            builder.AddAttribute(renderer.Sequence++, "Style", $"font-family: {FontFamily}");
 
             if (level == 2)
             {

--- a/src/Nullkooland.Client/Services/Markdown/Renderers/ListRenderer.cs
+++ b/src/Nullkooland.Client/Services/Markdown/Renderers/ListRenderer.cs
@@ -14,7 +14,7 @@ namespace Nullkooland.Client.Services.Markdown.Renderers
             {
                 var item = (listBlock[i] as ListItemBlock)!;
                 builder.OpenElement(renderer.Sequence++, "div");
-                builder.AddAttribute(renderer.Sequence++, "class", "ml-4 d-flex flex-row justify-start align-center");
+                builder.AddAttribute(renderer.Sequence++, "class", "ml-4 d-flex flex-row justify-start align-start");
 
                 builder.OpenComponent<MudText>(renderer.Sequence++);
                 builder.AddAttribute(renderer.Sequence++, "Class", "mr-2");

--- a/src/Nullkooland.Client/ViewModels/Pages/PostPageViewModel.cs
+++ b/src/Nullkooland.Client/ViewModels/Pages/PostPageViewModel.cs
@@ -45,9 +45,9 @@ namespace Nullkooland.Client.ViewModels.Pages
         public string? TitleFontFamily => Post?.Type switch
         {
             BlogPostType.Technical => "Roboto Slab",
-            BlogPostType.Personal => "LXGW WenKai",
-            BlogPostType.Ramblings => "LXGW WenKai",
-            _ => "Roboto",
+            BlogPostType.Personal => "Noto Serif SC",
+            BlogPostType.Ramblings => "Noto Serif SC",
+            _ => "sans-serif",
         };
 
         public string? CommentTitle => Post?.Type switch
@@ -81,9 +81,9 @@ namespace Nullkooland.Client.ViewModels.Pages
             string? fontFamily = Post?.Type switch
             {
                 BlogPostType.Technical => "Roboto, sans-serif",
-                BlogPostType.Personal => "LXGW WenKai",
-                BlogPostType.Ramblings => "LXGW WenKai",
-                _ => "Roboto",
+                BlogPostType.Personal => "Noto Serif SC",
+                BlogPostType.Ramblings => "Noto Serif SC",
+                _ => "sans-serif",
             };
 
             Markdown = _markdownRenderService.Render(content, fontFamily, Post.Url);

--- a/src/Nullkooland.Client/Views/Pages/AboutPage.razor
+++ b/src/Nullkooland.Client/Views/Pages/AboutPage.razor
@@ -181,30 +181,6 @@
                 </MudCardHeader>
             </MudCard>
         </MudItem>
-
-        <MudItem xs="12" md="6" lg="3" xl="2">
-            <MudCard Elevation="2" Style="height: 96px">
-                <MudCardHeader>
-                    <CardHeaderAvatar>
-                        <div class="dependency-logo">
-                            <MudText Typo="Typo.h3" Style="font-family: 'LXGW WenKai'">
-                                鹜
-                            </MudText>
-                        </div>
-                    </CardHeaderAvatar>
-                    <CardHeaderContent>
-                        <MudLink Typo="Typo.body1"
-                                 Color="Color.Secondary"
-                                 Href="https://github.com/lxgw/LxgwWenKai">
-                            <b>霞鹜文楷</b>
-                        </MudLink>
-                        <MudText Typo="Typo.body2">
-                            Chinese font for lighthearted posts.
-                        </MudText>
-                    </CardHeaderContent>
-                </MudCardHeader>
-            </MudCard>
-        </MudItem>
     </MudGrid>
 
 </MudContainer>

--- a/src/Nullkooland.Client/wwwroot/index.html
+++ b/src/Nullkooland.Client/wwwroot/index.html
@@ -8,11 +8,13 @@
     <link rel="icon" type="image/png" href="images/icon.png">
 
     <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Slab&display=swap">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
-    <link rel="stylesheet" href="https://unpkg.com/firacode/distr/fira_code.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/lxgw-wenkai-webfont@0/style.min.css" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@300..700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400..700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Serif+SC:wght@400;700&display=swap" media="print" onload="this.media='all'">
+
 
     <!-- MudBlazor -->
     <link rel="stylesheet" href="_content/MudBlazor/MudBlazor.min.css" />

--- a/src/Nullkooland.Client/wwwroot/index.html
+++ b/src/Nullkooland.Client/wwwroot/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="_content/MudBlazor/MudBlazor.min.css" />
 
     <!-- Other stylesheets -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.18/dist/katex.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
     <link rel="stylesheet" type="text/css" href="css/prism.css">
     <link rel="stylesheet" type="text/css" href="css/katex.css">
 </head>
@@ -37,7 +37,7 @@
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.13.18/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
     <script src="js/prism.js"></script>
     <script src="js/dark-mode-helper.js"></script>
     <script src="js/utterances-helper.js"></script>


### PR DESCRIPTION
还是思源宋体比较彳亍，就不用霞鹜文楷啦，可能主要是后者加载太慢。
要是 Google Fonts 的思源宋体是可变字体的话就更彳亍啦，可惜现在还不支持。